### PR TITLE
Add on delete and on update behaviour for the foreign key #81

### DIFF
--- a/SQLite/databaseSchema.sql
+++ b/SQLite/databaseSchema.sql
@@ -21,4 +21,6 @@ create table notification(
     userid Integer,
     attributes varchar(255),
     Foreign Key (userid) References user(userid)
+        On Delete Cascade
+        On Update Cascade
 );


### PR DESCRIPTION
Sets notification to cascade on delete and update, so when a user is removed from the database so will their associated notifications. Also if a user's userid changes it will still associate them with the correct notifications. ( Their userid should never be updated though)