### PR TITLE
sendEmail can send emails given a body and an address #105

### DIFF
--- a/flaskr/notifications/emailTest.py
+++ b/flaskr/notifications/emailTest.py
@@ -1,0 +1,12 @@
+
+import sendEmail as sendEmail
+
+# This will send me an email each time it is run, please don't spam me
+
+print ('Running')
+
+body = 'This is a test email from python'
+recipient = 'ryanpybus8596@gmail.com';
+sendEmail.send_email(body,recipient);
+
+print('Finished')

--- a/flaskr/notifications/sendEmail.py
+++ b/flaskr/notifications/sendEmail.py
@@ -1,0 +1,51 @@
+import smtplib
+from email.mime.text import MIMEText
+from email.message import EmailMessage
+
+# Adapted from send_email by Anthony Argatoff
+# https://github.com/anthonyargatoff/furlong_co-op_scraping
+
+def send_email(body:str, recipient:str):
+    """
+    Args:
+        body (str): message body
+        recipient (str): recipient
+    """
+    port = 587  # For starttls
+    smtp_server = "smtp.gmail.com"
+
+    # email and app password for the gmail sending the emails.
+    sender_email = "quakebot9000@gmail.com"
+    password = 'lwdvrqlzofwlgfll'
+    subject = "QuakeQuest Notification";
+
+
+    #msg = MIMEText(body)
+    #msg['Subject'] = subject
+    #msg['From'] = sender_email
+    #msg['To'] = ', '.join(recipient)
+
+    #message = """\
+    #From: %s
+    #To: %s
+    #Subject: %s
+
+    #%s
+    #""" % (sender_email, recipient, subject, body);
+
+    #msg = EmailMessage()
+    #msg['Subject'] = subject
+    #msg['From'] = sender_email
+    #msg['To'] = recipient
+    #msg.set_content(body)
+
+    try:
+        with smtplib.SMTP(smtp_server, port) as server:
+            server.ehlo();
+            server.starttls();
+
+            server.login(sender_email, password);
+            server.sendmail(sender_email, recipient, body);
+            server.quit();
+    except Exception as error:
+        print('Error:', error);

--- a/flaskr/notifications/sendEmail.py
+++ b/flaskr/notifications/sendEmail.py
@@ -11,12 +11,12 @@ def send_email(body:str, recipient:str):
         body (str): message body
         recipient (str): recipient
     """
-    port = 587  # For starttls
-    smtp_server = "smtp.gmail.com"
+    port = 587;
+    smtp_server = "smtp.gmail.com";
 
     # email and app password for the gmail sending the emails.
-    sender_email = "quakebot9000@gmail.com"
-    password = 'lwdvrqlzofwlgfll'
+    sender_email = "quakebot9000@gmail.com";
+    password = 'lwdvrqlzofwlgfll';
     subject = "QuakeQuest Notification";
 
 


### PR DESCRIPTION
Pull request to close issue #105 
- Sends an email containing the string input as body.

- I imagine we would only send emails to one person at a time, but if we want to do multiples it would be easy to update the params to allow this

- Uses tls and an app password, for verbose reasons I can explain if you ask me to

- Currently subject is not working properly, contains some commented out code that I'm still working on.

- not sure how to test this, but the test file included just sends me an email. It does work (image) 
![image](https://github.com/anthonyargatoff/LifeCycle-Thugs/assets/144271014/35785158-2260-4b36-a267-f9cc943c0914)
