### PR TITLE
Remove: Bottom table

### DIFF
--- a/flaskr/templates/Search.html
+++ b/flaskr/templates/Search.html
@@ -96,30 +96,7 @@
 
     </div> <!-- Row -->
     <!-- Row 2: event details table -->
-    <div class="row">
-      <div class="col-12">
-        <table class="table table-hover">
-          <thead>
-            <tr>
-              <th scope="col">Location</th>
-              <th scope="col">Magnitude</th>
-              <th scope="col">Depth</th>
-              <th scope="col">Time</th>
-            </tr>
-          <tbody>
-            <tr>
-              <td>n/a</td>
-              <td>n/a</td>
-              <td>n/a</td>
-              <td>n/a</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
   </div>
-  {{ session['email'] }}
-  {% include 'footer.html' %}
 
   <script>
     document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Removed the bottom table under the map, since we haven't had time to implement it.
![image](https://github.com/anthonyargatoff/LifeCycle-Thugs/assets/122230360/34a346a0-5f89-475a-81f9-f482d906dc6b)
Closes #193 