### PR TITLE
Search Page: Update layout

### DIFF
--- a/flaskr/templates/Search.html
+++ b/flaskr/templates/Search.html
@@ -21,7 +21,7 @@
     <!-- Row 1: filter and map-->
     <div class="row row-cols-auto">
       <!-- Filter List Component-->
-      <div class="col col-md-4 col-lg-3">
+      <div class="col col-md-4 col-lg-3" style="padding-right: 0;">
         <div class="d-flex flex-column flex-shrink-0 p-3 bg-body-tertiary">
           <span class="fs-4">Search</span>
           <hr>
@@ -90,8 +90,8 @@
         </div>
       </div>
       <!-- Map element-->
-      <div class="col d-flex col-md-8 col-lg-9">
-        <div class="" id="map" style="width: 90em; height: auto;"></div>
+      <div class="col d-flex col-md-8 col-lg-9" style="padding: 0;">
+        <div class="" id="map" style="width: 100%; height: auto;"></div>
       </div>
 
     </div> <!-- Row -->


### PR DESCRIPTION
Removed white space on the search page. More use of the map.
![image](https://github.com/anthonyargatoff/LifeCycle-Thugs/assets/122230360/6d939737-b346-4d9e-a278-9d842fc0827e)
Closes #197 